### PR TITLE
Remove call to removed method in facter

### DIFF
--- a/lib/facter/tuned.rb
+++ b/lib/facter/tuned.rb
@@ -33,7 +33,7 @@ Facter.add('tuned_profile') do
       ]
 
       alternatives.each do |fn|
-        if FileTest.exists?(fn)
+        if FileTest.exist?(fn)
           result = File.foreach(fn).first.chomp
           break
         end


### PR DESCRIPTION
`File.exists?` was removed with ruby 3.2.0 https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Antoine